### PR TITLE
Wrapper script for `make`

### DIFF
--- a/make
+++ b/make
@@ -22,10 +22,11 @@ function fix-ros-path() {
     fi
 
     # Iterate through RPP and check if the current working directory
-    # is already present in ROS_PACKAGE_PATH. Return from the script if the
-    # current working directory is already present in ROS_PACKAGE_PATH.
+    # is already present in ROS_PACKAGE_PATH. Return from the function
+    # if the current working directory is already present in
+    # ROS_PACKAGE_PATH.
     for p in "${RPP[@]}"; do
-        # `-ef` comares device and inode numbers for equality
+        # `-ef` compares device and inode numbers for equality
         if [[ "$p" -ef "$CWD" ]]; then
             return
         fi


### PR DESCRIPTION
This PR introduces an executable script, `./make`, that inserts this repository's local path into the `ROS_PACKAGE_PATH` environment variable before running the real `make`.

Since the wrapper script modifies the `ROS_PACKAGE_PATH`, it should not be necessary to update shell dotfiles on every machine if the name of the assignment folder changes.

I'm open to renaming the file to distinguish it further from the real `make`.

Closes #2 