### PR TITLE
Convert log-likelihoods to linear-likelihoods in `GetLocation`.

### DIFF
--- a/src/particle_filter/particle_filter.cc
+++ b/src/particle_filter/particle_filter.cc
@@ -328,10 +328,8 @@ void ParticleFilter::Initialize(const string& map_file, const Vector2f& loc, con
 /**
  * Computes the best estimate of the robot's location based on the
  * current set of particles.
- *
- * CRITICAL: assumes particle weights are not log-likelihoods.
  */
-std::pair<Eigen::Vector2f, float> ParticleFilter::GetLocation() const {
+std::pair<Eigen::Vector2f, float> ParticleFilter::GetLocation() {
   // Compute the weighted mean of all the particles.
 
   // TODO: The mean is potentially suboptimal if the distribution of peaks
@@ -343,11 +341,14 @@ std::pair<Eigen::Vector2f, float> ParticleFilter::GetLocation() const {
   double mean_angle_sin = 0;
   double total_weight = 0;
 
+  NormalizeParticles();
+
   for (const Particle& p : particles_) {
-    mean_loc += p.loc * p.weight;
-    mean_angle_cos += std::cos(p.angle) * p.weight;
-    mean_angle_sin += std::sin(p.angle) * p.weight;
-    total_weight += p.weight;
+    const double linear_weight = std::exp(p.weight);
+    mean_loc += p.loc * linear_weight;
+    mean_angle_cos += std::cos(p.angle) * linear_weight;
+    mean_angle_sin += std::sin(p.angle) * linear_weight;
+    total_weight += linear_weight;
   }
 
   mean_loc /= total_weight;

--- a/src/particle_filter/particle_filter.h
+++ b/src/particle_filter/particle_filter.h
@@ -71,7 +71,7 @@ class ParticleFilter {
   const std::vector<Particle>& GetParticles() const;
 
   // Get robot's current location.
-  std::pair<Eigen::Vector2f, float> GetLocation() const;
+  std::pair<Eigen::Vector2f, float> GetLocation();
 
   // Update particle weight based on laser.
   void Update(const std::vector<float>& ranges,


### PR DESCRIPTION
In addition to fixing `GetLocation`, I moved particle normalization to its own function so we can reuse code.

In simulation, the car's estimated location is still pretty erratic, but this is due to our simple Gaussian sensor model - one particle's weight tends to overshadow all other weights.

Closes #45 