### PR TITLE
Use the Lua configuration file for particle filter hyperparameters

### DIFF
--- a/config/particle_filter.lua
+++ b/config/particle_filter.lua
@@ -2,3 +2,22 @@ map = "maps/GDC1.txt"
 init_x = 14.7
 init_y = 14.24
 init_r = 0
+
+-- Error in translation caused by translation.
+motion_model_k1 = 1
+-- Error in translation caused by rotation.
+motion_model_k2 = 0.5
+-- Error in rotation caused by translation.
+motion_model_k3 = 0.5
+-- Error in rotation caused by rotation.
+motion_model_k4 = 0.5
+
+
+lidar_stddev = 0.1  -- meters, inflated
+
+-- The bound around the expected LIDAR reading in which a Gaussian
+-- distribution is used.
+sensor_model_d_short = -1.5 * lidar_stddev
+sensor_model_d_long = 1.5 * lidar_stddev
+
+sensor_model_gamma = 0.6


### PR DESCRIPTION
This change specifies the hyperparameters we need to tune in `particle_filter.lua` rather than as constants in the C++ file so that adjustments do not necessitate recompilation.