### PR TITLE
Add proper await semantics to CSM

### DIFF
--- a/src/slam/raster_map.cc
+++ b/src/slam/raster_map.cc
@@ -5,7 +5,6 @@
 #include <limits>
 #include <unordered_set>
 #include <vector>
-#include "common/common.hh"
 #include "eigen3/Eigen/Dense"
 #include "models/sensor.hh"
 #include "sensor_msgs/LaserScan.h"
@@ -30,7 +29,6 @@ RasterMap::RasterMap(const int resolution) : resolution_(resolution), raster_tab
  * point until the probability falls below a threshold.
  */
 void RasterMap::eval(const sensor_msgs::LaserScan& obs) {
-  auto __delayedfn = common::runtime_dist.auto_lap("RasterMap::eval");
   raster_table_.clear();
 
   // Keep track of which bins contain observation points. Assume

--- a/src/slam/slam.cc
+++ b/src/slam/slam.cc
@@ -61,16 +61,33 @@ const int global_rot_resolution = 1;
 
 namespace slam {
 
-SLAMBelief::SLAMBelief()
-    : odom_disp(),
-      odom_angle_disp(),
-      obs(),
-      belief_disp(),
-      belief_angle_disp(),
-      belief_loc(),
-      belief_angle(),
-      coarse_ref_map(coarse_tx_resolution),
-      fine_ref_map(fine_tx_resolution) {}
+SLAMBelief::SLAMBelief(const Eigen::Vector2f& prev_odom_loc,
+                       const float prev_odom_angle,
+                       const Eigen::Vector2f& odom_loc,
+                       const float odom_angle,
+                       const sensor_msgs::LaserScan& obs)
+    : odom_disp(Eigen::Rotation2Df(-prev_odom_angle) * (odom_loc - prev_odom_loc)),
+      odom_angle_disp(math_util::ReflexToConvexAngle(odom_angle - prev_odom_angle)),
+      obs(obs) {
+  auto fine_promise = std::make_shared<std::promise<RasterMap>>();
+  auto coarse_promise = std::make_shared<std::promise<RasterMap>>();
+  this->fine_ref_map = fine_promise->get_future().share();
+  this->coarse_ref_map = coarse_promise->get_future().share();
+
+  common::thread_pool.put([this, fine_promise] {
+    auto __delayedfn = common::runtime_dist.auto_lap("Fine RasterMap");
+    RasterMap fine_map(fine_tx_resolution);
+    fine_map.eval(this->obs);
+    fine_promise->set_value(std::move(fine_map));
+  });
+
+  common::thread_pool.put([this, coarse_promise] {
+    auto __delayedfn = common::runtime_dist.auto_lap("Coarse RasterMap");
+    RasterMap coarse_map(coarse_tx_resolution);
+    coarse_map.eval(this->obs);
+    coarse_promise->set_value(std::move(coarse_map));
+  });
+}
 
 std::vector<Eigen::Vector2f> SLAMBelief::correlated_points(const RasterMap& prev_ref_map) const {
   std::vector<Eigen::Vector2f> obs_points = models::PointsFromScan(obs);
@@ -119,22 +136,21 @@ void SLAM::ObserveLaser(const sensor_msgs::LaserScan& obs) {
 
   static Eigen::Vector2f last_obs_odom_loc(0, 0);
   static float last_obs_odom_angle = 0.0f;
-  static bool bel_initialized = false;
 
   if (!odom_initialized_) {
     return;
   }
 
-  if (!bel_initialized) {
-    SLAMBelief init_bel;
-    init_bel.obs = obs;
-    init_bel.coarse_ref_map.eval(init_bel.obs);
-    init_bel.fine_ref_map.eval(init_bel.obs);
+  if (belief_history.empty()) {
+    belief_history.emplace_back(last_obs_odom_loc, last_obs_odom_angle, prev_odom_loc_,
+                                prev_odom_angle_, obs);
+    belief_history.back().belief_disp = Eigen::Vector2f(0, 0);
+    belief_history.back().belief_angle_disp = 0;
+    belief_history.back().belief_loc = Eigen::Vector2f(0, 0);
+    belief_history.back().belief_angle = 0;
 
     last_obs_odom_loc = prev_odom_loc_;
     last_obs_odom_angle = prev_odom_angle_;
-    belief_history.push_back(std::move(init_bel));
-    bel_initialized = true;
     return;
   }
 
@@ -148,28 +164,18 @@ void SLAM::ObserveLaser(const sensor_msgs::LaserScan& obs) {
 
   auto __delayedfn = common::runtime_dist.auto_lap("SLAM::ObserveLaser");
 
-  SLAMBelief bel;
-  bel.odom_disp = Eigen::Rotation2Df(-last_obs_odom_angle) * (prev_odom_loc_ - last_obs_odom_loc);
-  bel.odom_angle_disp = math_util::ReflexToConvexAngle(prev_odom_angle_ - last_obs_odom_angle);
+  SLAMBelief bel(last_obs_odom_loc, last_obs_odom_angle, prev_odom_loc_, prev_odom_angle_, obs);
   last_obs_odom_loc = prev_odom_loc_;
   last_obs_odom_angle = prev_odom_angle_;
-
-  bel.obs = obs;
-
-  // Execute these tasks in the background.
-  // RasterMap::eval generally runs faster than BeliefCube::eval, but this could
-  // potentially cause a segfault if `bel` goes out of scope. (fix: wrap & await)
-  common::thread_pool.put(std::bind(&RasterMap::eval, &bel.fine_ref_map, bel.obs));
-  common::thread_pool.put(std::bind(&RasterMap::eval, &bel.coarse_ref_map, bel.obs));
 
   BeliefCube coarse_cube(global_tx_windowsize, coarse_tx_resolution, global_rot_windowsize,
                          global_rot_resolution);
   BeliefCube fine_cube(global_tx_windowsize, fine_tx_resolution, global_rot_windowsize,
                        global_rot_resolution);
 
-  coarse_cube.eval(belief_history.back().coarse_ref_map, bel.odom_disp, bel.odom_angle_disp,
+  coarse_cube.eval(belief_history.back().coarse_ref_map.get(), bel.odom_disp, bel.odom_angle_disp,
                    bel.obs, true, true);
-  fine_cube.eval_with_coarse(belief_history.back().fine_ref_map, bel.odom_disp,
+  fine_cube.eval_with_coarse(belief_history.back().fine_ref_map.get(), bel.odom_disp,
                              bel.odom_angle_disp, bel.obs, coarse_cube);
 
   const std::pair<Eigen::Vector2f, double> max_prob_belief = fine_cube.max_belief();
@@ -210,7 +216,8 @@ vector<Vector2f> SLAM::GetMap() {
     const SLAMBelief& bel = belief_history[i];
 
     std::vector<Eigen::Vector2f> points = models::PointsFromScan(bel.obs);
-    std::vector<Eigen::Vector2f> corrs = bel.correlated_points(belief_history[i - 1].fine_ref_map);
+    std::vector<Eigen::Vector2f> corrs =
+        bel.correlated_points(belief_history[i - 1].fine_ref_map.get());
     printf("[SLAM::GetMap INFO] points: %lu, correlations: %lu\n", points.size(), corrs.size());
     const Eigen::Rotation2Df bel_rot(bel.belief_angle);
     for (const Eigen::Vector2f& point : corrs) {

--- a/src/slam/slam.h
+++ b/src/slam/slam.h
@@ -20,6 +20,7 @@
 //========================================================================
 
 #include <algorithm>
+#include <future>
 #include <vector>
 
 #include "belief_cube.hh"
@@ -36,22 +37,26 @@ namespace slam {
 // Components of the probabilistic model of the SLAM belief
 // at an arbitrary timestep.
 struct SLAMBelief {
-  SLAMBelief();
+  SLAMBelief(const Eigen::Vector2f& prev_odom_loc,
+             const float prev_odom_angle,
+             const Eigen::Vector2f& odom_loc,
+             const float odom_angle,
+             const sensor_msgs::LaserScan& obs);
 
-  // for use in this time step
+  // evidence for this time step
   Eigen::Vector2f odom_disp;
   float odom_angle_disp;
   sensor_msgs::LaserScan obs;
 
-  // to compute
+  // posterior belief of this time step
   Eigen::Vector2f belief_disp;
   float belief_angle_disp;
   Eigen::Vector2f belief_loc;
   float belief_angle;
 
-  // for use in the next time step
-  RasterMap coarse_ref_map;
-  RasterMap fine_ref_map;
+  // evidence for the next time step
+  std::shared_future<RasterMap> coarse_ref_map;
+  std::shared_future<RasterMap> fine_ref_map;
 
   std::vector<Eigen::Vector2f> correlated_points(const RasterMap& prev_ref_map) const;
 };

--- a/src/slam/slam.h
+++ b/src/slam/slam.h
@@ -73,8 +73,6 @@ class SLAM {
   // Get latest robot pose.
   std::pair<Eigen::Vector2f, float> GetPose() const;
 
-  void OfflineBelEvaluation();
-
  private:
   // Previous odometry-reported locations.
   Eigen::Vector2f prev_odom_loc_;
@@ -82,7 +80,6 @@ class SLAM {
   bool odom_initialized_;
 
   std::vector<SLAMBelief> belief_history;
-  bool offline_eval_;
 
   IdentityRasterMap map_;
 };


### PR DESCRIPTION
SLAMBelief has been reworked to perform evaluations previously done in ObserveLaser. The raster maps have been wrapped in `shared_future`s to enable proper await semantics for the asynchronous evaluation.

Closes #84