### PR TITLE
Rework CSM using Density-Aware Sampling

### DIFF
--- a/src/models/constraints.hh
+++ b/src/models/constraints.hh
@@ -18,7 +18,7 @@ constexpr float kSafetyMargin = 0.07;                          // m
 constexpr float kWheelBase = 0.33;                             // m
 const float kMinSteeringAngle = std::atan(kWheelBase / -1.1);  // rad
 const float kMaxSteeringAngle = std::atan(kWheelBase / 1.1);   // rad
-const Eigen::Vector2f kLaserLoc(0.2, 0);
+const Eigen::Vector2f kLaserOffset(0.2, 0);
 // Define the boundaries of the car in terms of its corners
 // in each quadrant of the base_link reference frame.
 const Eigen::Vector2f q1_corner(kBaseToFront + kSafetyMargin, kBaseToSide + kSafetyMargin);

--- a/src/models/sensor.cc
+++ b/src/models/sensor.cc
@@ -115,27 +115,6 @@ Observations Observations::density_aware_sample(const double sampling_fraction) 
   return sample;
 }
 
-std::vector<Eigen::Vector2f> PointsFromScan(const sensor_msgs::LaserScan& scan) {
-  const std::vector<float>& ranges = scan.ranges;
-  const size_t n_ranges = ranges.size();
-
-  std::vector<Eigen::Vector2f> points;
-  points.reserve(n_ranges);
-
-  for (size_t i = 0; i < n_ranges; i++) {
-    const float scan_range = ranges[i];
-    if (scan_range <= scan.range_min || scan_range >= scan.range_max) {
-      continue;
-    }
-
-    const float scan_angle = scan.angle_min + i * scan.angle_increment;
-    const Eigen::Rotation2Df scan_rot(scan_angle);
-    points.push_back(kLaserOffset + scan_rot * Eigen::Vector2f(scan_range, 0));
-  }
-
-  return points;
-}
-
 double EvalLogSensorModel(const Eigen::Vector2f& expected_obs, const Eigen::Vector2f& sample_obs) {
   const float range_diff = (expected_obs - sample_obs).norm();
   return LnOfNormalPdf(range_diff, 0, kLidarStddev) - kLogObsNormalization;

--- a/src/models/sensor.cc
+++ b/src/models/sensor.cc
@@ -136,14 +136,7 @@ std::vector<Eigen::Vector2f> PointsFromScan(const sensor_msgs::LaserScan& scan) 
   return points;
 }
 
-double EvalLogSensorModel(const sensor_msgs::LaserScan& scan_info,
-                          const Eigen::Vector2f& expected_obs,
-                          const Eigen::Vector2f& sample_obs) {
-  const float sample_range = (sample_obs - kLaserOffset).norm();
-  if (sample_range <= scan_info.range_min || sample_range >= scan_info.range_max) {
-    return -std::numeric_limits<double>::infinity();
-  }
-
+double EvalLogSensorModel(const Eigen::Vector2f& expected_obs, const Eigen::Vector2f& sample_obs) {
   const float range_diff = (expected_obs - sample_obs).norm();
   return LnOfNormalPdf(range_diff, 0, kLidarStddev) - kLogObsNormalization;
 }

--- a/src/models/sensor.cc
+++ b/src/models/sensor.cc
@@ -33,7 +33,7 @@ std::vector<Eigen::Vector2f> PointsFromScan(const sensor_msgs::LaserScan& scan) 
 
     const float scan_angle = scan.angle_min + i * scan.angle_increment;
     const Eigen::Rotation2Df scan_rot(scan_angle);
-    points.push_back(kLaserLoc + scan_rot * Eigen::Vector2f(scan_range, 0));
+    points.push_back(kLaserOffset + scan_rot * Eigen::Vector2f(scan_range, 0));
   }
 
   return points;
@@ -42,7 +42,7 @@ std::vector<Eigen::Vector2f> PointsFromScan(const sensor_msgs::LaserScan& scan) 
 double EvalLogSensorModel(const sensor_msgs::LaserScan& scan_info,
                           const Eigen::Vector2f& expected_obs,
                           const Eigen::Vector2f& sample_obs) {
-  const float sample_range = (sample_obs - kLaserLoc).norm();
+  const float sample_range = (sample_obs - kLaserOffset).norm();
   if (sample_range <= scan_info.range_min || sample_range >= scan_info.range_max) {
     return -std::numeric_limits<double>::infinity();
   }

--- a/src/models/sensor.cc
+++ b/src/models/sensor.cc
@@ -52,6 +52,15 @@ Observations::Observations(const sensor_msgs::LaserScan& scan,
   point_cloud_ = A_laser_to_map * point_cloud_;
 }
 
+Observations::Observations(std::vector<LaserRange>&& ranges,
+                           const Eigen::Vector2f& robot_loc,
+                           const float robot_angle,
+                           Eigen::Matrix<float, 2, Eigen::Dynamic>&& point_cloud)
+    : ranges_(ranges),
+      robot_loc_(robot_loc),
+      robot_angle_(robot_angle),
+      point_cloud_(point_cloud) {}
+
 Observations Observations::density_aware_sample(const double sampling_fraction) const {
   if (sampling_fraction < 0.0 || sampling_fraction > 1.0) {
     throw std::invalid_argument("[Observations::density_aware_sample] invalid sampling fraction");

--- a/src/models/sensor.hh
+++ b/src/models/sensor.hh
@@ -84,12 +84,10 @@ std::vector<Eigen::Vector2f> PointsFromScan(const sensor_msgs::LaserScan& scan);
 
 /**
  * Evaluate the log-likelihood of the observation likelihood model.
- * The observation points should be in the base link reference frame of
- * the car.
+ * The observation points should be valid and in the base link reference
+ * frame of the car.
  */
-double EvalLogSensorModel(const sensor_msgs::LaserScan& scan_info,
-                          const Eigen::Vector2f& expected_obs,
-                          const Eigen::Vector2f& sample_obs);
+double EvalLogSensorModel(const Eigen::Vector2f& expected_obs, const Eigen::Vector2f& sample_obs);
 
 /**
  * Same as above, but assume the the two ranges are valid and have the

--- a/src/models/sensor.hh
+++ b/src/models/sensor.hh
@@ -36,6 +36,15 @@ class Observations {
   const std::vector<LaserRange>& ranges() const { return ranges_; }
   const Eigen::Matrix<float, 2, Eigen::Dynamic>& point_cloud() const { return point_cloud_; }
 
+  /**
+   * Return a density-aware sample of this Observations instance with
+   * the specified sampling fraction.
+   */
+  Observations density_aware_sample(const double sampling_fraction = 0.1) const;
+
+ private:
+  Observations() = default;
+
  private:
   // Sensor readings in the laser reference frame.
   std::vector<LaserRange> ranges_;

--- a/src/models/sensor.hh
+++ b/src/models/sensor.hh
@@ -8,6 +8,51 @@
 namespace models {
 
 /**
+ * A unified format for sensor Observations.
+ *
+ * Stores valid ranges in the laser reference frame and their
+ * corresponding points in the map frame.
+ */
+class Observations {
+ public:
+  struct LaserRange {
+    size_t msg_idx;
+    float dist;
+    float angle;
+    bool valid;
+  };
+
+ public:
+  /**
+   * Initialize an Observations instance from a LaserScan message.
+   *
+   * The default parameters for robot_loc and robot_angle construct the
+   * point cloud in the base_link reference frame.
+   */
+  Observations(const sensor_msgs::LaserScan& scan,
+               const Eigen::Vector2f& robot_loc = Eigen::Vector2f(0, 0),
+               const float robot_angle = 0);
+
+  const std::vector<LaserRange>& ranges() const { return ranges_; }
+  const Eigen::Matrix<float, 2, Eigen::Dynamic>& point_cloud() const { return point_cloud_; }
+
+ private:
+  // Sensor readings in the laser reference frame.
+  std::vector<LaserRange> ranges_;
+
+  // Pose of the robot in the map frame at observation time.
+  Eigen::Vector2f robot_loc_;
+  float robot_angle_;
+
+  /**
+   * Point cloud representation in the map frame.
+   * If robot_loc_ and robot_angle_ are both zero, the point cloud
+   *   is in the base_link reference frame.
+   */
+  Eigen::Matrix<float, 2, Eigen::Dynamic> point_cloud_;
+};
+
+/**
  * Return a point cloud of observations in the base link reference
  * frame of the car from the valid sensor observations in the scan
  * message.

--- a/src/models/sensor.hh
+++ b/src/models/sensor.hh
@@ -76,13 +76,6 @@ class Observations {
 };
 
 /**
- * Return a point cloud of observations in the base link reference
- * frame of the car from the valid sensor observations in the scan
- * message.
- */
-std::vector<Eigen::Vector2f> PointsFromScan(const sensor_msgs::LaserScan& scan);
-
-/**
  * Evaluate the log-likelihood of the observation likelihood model.
  * The observation points should be valid and in the base link reference
  * frame of the car.

--- a/src/models/sensor.hh
+++ b/src/models/sensor.hh
@@ -33,6 +33,14 @@ class Observations {
                const Eigen::Vector2f& robot_loc = Eigen::Vector2f(0, 0),
                const float robot_angle = 0);
 
+  /**
+   * Fake move-constructor in lieu of friendship.
+   */
+  Observations(std::vector<LaserRange>&& ranges,
+               const Eigen::Vector2f& robot_loc,
+               const float robot_angle,
+               Eigen::Matrix<float, 2, Eigen::Dynamic>&& point_cloud);
+
   const std::vector<LaserRange>& ranges() const { return ranges_; }
   const Eigen::Matrix<float, 2, Eigen::Dynamic>& point_cloud() const { return point_cloud_; }
 

--- a/src/models/sensor.hh
+++ b/src/models/sensor.hh
@@ -36,7 +36,9 @@ class Observations {
   /**
    * Fake move-constructor in lieu of friendship.
    */
-  Observations(std::vector<LaserRange>&& ranges,
+  Observations(const float min_range_dist,
+               const float max_range_dist,
+               std::vector<LaserRange>&& ranges,
                const Eigen::Vector2f& robot_loc,
                const float robot_angle,
                Eigen::Matrix<float, 2, Eigen::Dynamic>&& point_cloud);
@@ -51,7 +53,11 @@ class Observations {
   Observations density_aware_sample(const double sampling_fraction = 0.1) const;
 
  private:
-  Observations() = default;
+  Observations(const float min_range_dist, const float max_range_dist);
+
+ public:
+  const float min_range_dist_;
+  const float max_range_dist_;
 
  private:
   // Sensor readings in the laser reference frame.
@@ -62,7 +68,7 @@ class Observations {
   float robot_angle_;
 
   /**
-   * Point cloud representation in the map frame.
+   * Point cloud representation of valid ranges in the map frame.
    * If robot_loc_ and robot_angle_ are both zero, the point cloud
    *   is in the base_link reference frame.
    */

--- a/src/particle_filter/particle_filter.cc
+++ b/src/particle_filter/particle_filter.cc
@@ -181,7 +181,9 @@ models::Observations ParticleFilter::GetPredictedPointCloud(const Vector2f& loc,
     }
   }
 
-  return models::Observations(std::move(predicted_ranges), loc, angle,
+  // TODO: Violates the point cloud validity property, but the caller handles this.
+  return models::Observations(real_obs.min_range_dist_, real_obs.max_range_dist_,
+                              std::move(predicted_ranges), loc, angle,
                               std::move(predicted_point_cloud));
 }
 

--- a/src/particle_filter/particle_filter.h
+++ b/src/particle_filter/particle_filter.h
@@ -26,6 +26,7 @@
 
 #include "eigen3/Eigen/Dense"
 #include "eigen3/Eigen/Geometry"
+#include "models/sensor.hh"
 #include "sensor_msgs/LaserScan.h"
 #include "shared/math/line2d.h"
 #include "shared/util/random.h"
@@ -50,18 +51,6 @@ struct Particle {
       : loc(std::move(loc)), angle(angle), weight(weight) {}
 };
 
-struct Observation {
-  Observation() : valid(false), msg_idx(-1), range(-1), angle(0), obs_point(0, 0) {}
-
-  bool valid;
-  int msg_idx;
-  float range;  // in sensor reference frame
-  float angle;  // in sensor reference frame
-
-  // May not necessarily be assigned.
-  Eigen::Vector2f obs_point;  // in map frame
-};
-
 class ParticleFilter {
  public:
   // Default Constructor.
@@ -83,7 +72,7 @@ class ParticleFilter {
   std::pair<Eigen::Vector2f, float> GetLocation() const;
 
   // Update particle weight based on laser.
-  void Update(const std::vector<Observation>& ranges,
+  void Update(const models::Observations& obs,
               const float range_min,
               const float range_max,
               Particle& particle);
@@ -92,13 +81,11 @@ class ParticleFilter {
   void Resample();
 
   // For debugging: get predicted point cloud from current location.
-  std::vector<Observation> GetPredictedPointCloud(const Eigen::Vector2f& loc,
-                                                  const float angle,
-                                                  const std::vector<Observation>& ref_scan,
-                                                  const float range_min,
-                                                  const float range_max) const;
-
-  std::vector<Observation> DensitySampledPointCloud(const std::vector<Observation>& point_cloud);
+  models::Observations GetPredictedPointCloud(const Eigen::Vector2f& loc,
+                                              const float angle,
+                                              const models::Observations& real_obs,
+                                              const float range_min,
+                                              const float range_max) const;
 
  private:
   // List of particles being tracked.

--- a/src/particle_filter/particle_filter_main.cc
+++ b/src/particle_filter/particle_filter_main.cc
@@ -116,15 +116,15 @@ void PublishPredictedScan() {
   const auto [robot_loc, robot_angle] = particle_filter_.GetLocation();
 
   models::Observations real_obs(last_laser_msg_);
+  models::Observations sampled_obs = real_obs.density_aware_sample(0.1);
 
-  common::runtime_dist.start_lap("GetPredictedPointCloud (full scan)");
+  common::runtime_dist.start_lap("GetPredictedPointCloud (main)");
   models::Observations predicted_obs = particle_filter_.GetPredictedPointCloud(
-      robot_loc, robot_angle, real_obs, last_laser_msg_.range_min, last_laser_msg_.range_max);
-  common::runtime_dist.end_lap("GetPredictedPointCloud (full scan)");
+      robot_loc, robot_angle, sampled_obs, last_laser_msg_.range_min, last_laser_msg_.range_max);
+  common::runtime_dist.end_lap("GetPredictedPointCloud (main)");
 
-  models::Observations sampled_obs = predicted_obs.density_aware_sample(0.1);
-  for (size_t i = 0; i < sampled_obs.ranges().size(); i++) {
-    DrawPoint(sampled_obs.point_cloud().col(i), kColor, vis_msg_);
+  for (size_t i = 0; i < predicted_obs.ranges().size(); i++) {
+    DrawPoint(predicted_obs.point_cloud().col(i), kColor, vis_msg_);
   }
 }
 

--- a/src/slam/belief_cube.cc
+++ b/src/slam/belief_cube.cc
@@ -198,7 +198,6 @@ double BeliefCube::eval_range(const RasterMap& ref_map,
   // cannot be greater than the maximum likelihood.
   double max_prob = -std::numeric_limits<double>::infinity();
   double max_obs_prob = max_prob;
-  models::Observations sampled_obs = new_obs.density_aware_sample(0.1);
 
   while (!plausible_entries.empty()) {
     Entry e = plausible_entries.top();
@@ -215,13 +214,13 @@ double BeliefCube::eval_range(const RasterMap& ref_map,
     const double prune_threshold = max_prob - log_motion_prob;
     bool prune = false;
 
-    for (Eigen::Index sample_i = 0; sample_i < sampled_obs.point_cloud().cols(); sample_i++) {
-      const Eigen::Vector2f& point = sampled_obs.point_cloud().col(sample_i);
+    for (Eigen::Index obs_i = 0; obs_i < new_obs.point_cloud().cols(); obs_i++) {
+      const Eigen::Vector2f& point = new_obs.point_cloud().col(obs_i);
 
       // Translate the observation into the previous reference frame.
       const Eigen::Vector2f query_point = dtheta_rot * point + d_loc;
       const float query_dist = query_point.norm();
-      if (query_dist <= sampled_obs.min_range_dist_ || query_dist >= sampled_obs.max_range_dist_) {
+      if (query_dist <= new_obs.min_range_dist_ || query_dist >= new_obs.max_range_dist_) {
         continue;
       }
 

--- a/src/slam/belief_cube.cc
+++ b/src/slam/belief_cube.cc
@@ -198,6 +198,7 @@ double BeliefCube::eval_range(const RasterMap& ref_map,
   // cannot be greater than the maximum likelihood.
   double max_prob = -std::numeric_limits<double>::infinity();
   double max_obs_prob = max_prob;
+  models::Observations sampled_obs = new_obs.density_aware_sample(0.1);
 
   while (!plausible_entries.empty()) {
     Entry e = plausible_entries.top();
@@ -214,13 +215,13 @@ double BeliefCube::eval_range(const RasterMap& ref_map,
     const double prune_threshold = max_prob - log_motion_prob;
     bool prune = false;
 
-    for (Eigen::Index scan_i = 0; scan_i < new_obs.point_cloud().cols(); scan_i += 10) {
-      const Eigen::Vector2f& point = new_obs.point_cloud().col(scan_i);
+    for (Eigen::Index sample_i = 0; sample_i < sampled_obs.point_cloud().cols(); sample_i++) {
+      const Eigen::Vector2f& point = sampled_obs.point_cloud().col(sample_i);
 
       // Translate the observation into the previous reference frame.
       const Eigen::Vector2f query_point = dtheta_rot * point + d_loc;
       const float query_dist = query_point.norm();
-      if (query_dist <= new_obs.min_range_dist_ || query_dist >= new_obs.max_range_dist_) {
+      if (query_dist <= sampled_obs.min_range_dist_ || query_dist >= sampled_obs.max_range_dist_) {
         continue;
       }
 

--- a/src/slam/belief_cube.cc
+++ b/src/slam/belief_cube.cc
@@ -13,7 +13,6 @@
 #include "models/normdist.hh"
 #include "models/sensor.hh"
 #include "raster_map.hh"
-#include "sensor_msgs/LaserScan.h"
 #include "util/matrix_hash.hh"
 
 namespace slam {
@@ -53,7 +52,7 @@ decltype(auto) BeliefCube::max_index_iterator() const {
 void BeliefCube::eval(const RasterMap& ref_map,
                       const Eigen::Vector2f& odom_disp,
                       const double odom_angle_disp,
-                      const sensor_msgs::LaserScan& new_obs,
+                      const models::Observations& new_obs,
                       const bool ignore_motion_model,
                       const bool enable_obs_pruning) {
   auto __delayedfn = common::runtime_dist.auto_lap("BeliefCube::eval");
@@ -78,7 +77,7 @@ struct Entry {
 void BeliefCube::eval_with_coarse(const RasterMap& ref_map,
                                   const Eigen::Vector2f& odom_disp,
                                   const double odom_angle_disp,
-                                  const sensor_msgs::LaserScan& new_obs,
+                                  const models::Observations& new_obs,
                                   const BeliefCube& coarse_cube) {
   auto __delayedfn = common::runtime_dist.auto_lap("BeliefCube::eval_with_coarse");
 
@@ -147,7 +146,7 @@ void BeliefCube::eval_with_coarse(const RasterMap& ref_map,
 double BeliefCube::eval_range(const RasterMap& ref_map,
                               const Eigen::Vector2f& odom_disp,
                               const double odom_angle_disp,
-                              const sensor_msgs::LaserScan& new_obs,
+                              const models::Observations& new_obs,
                               const int dtheta_start,
                               const int dtheta_end,
                               const int dx_start,
@@ -197,7 +196,6 @@ double BeliefCube::eval_range(const RasterMap& ref_map,
   // we can keep track of the running maximium likelihood and prune
   // while evaluating the model if we know that the current likelihood
   // cannot be greater than the maximum likelihood.
-  const std::vector<Eigen::Vector2f> obs_points = models::PointsFromScan(new_obs);
   double max_prob = -std::numeric_limits<double>::infinity();
   double max_obs_prob = max_prob;
 
@@ -216,13 +214,13 @@ double BeliefCube::eval_range(const RasterMap& ref_map,
     const double prune_threshold = max_prob - log_motion_prob;
     bool prune = false;
 
-    for (size_t scan_i = 0; scan_i < obs_points.size(); scan_i += 10) {
-      const Eigen::Vector2f& point = obs_points[scan_i];
+    for (Eigen::Index scan_i = 0; scan_i < new_obs.point_cloud().cols(); scan_i += 10) {
+      const Eigen::Vector2f& point = new_obs.point_cloud().col(scan_i);
 
       // Translate the observation into the previous reference frame.
       const Eigen::Vector2f query_point = dtheta_rot * point + d_loc;
       const float query_dist = query_point.norm();
-      if (query_dist <= new_obs.range_min || query_dist >= new_obs.range_max) {
+      if (query_dist <= new_obs.min_range_dist_ || query_dist >= new_obs.max_range_dist_) {
         continue;
       }
 

--- a/src/slam/belief_cube.hh
+++ b/src/slam/belief_cube.hh
@@ -38,7 +38,7 @@ class BeliefCube {
    *      correlative scan matching.
    *  - odom_disp: The odometry displacement data for the motion model.
    *  - odom_angle_disp: The odometry rotation data for the motion model.
-   *  - new_obs: New observations for correlative scan matching.
+   *  - new_obs: New, sampled observations for correlative scan matching.
    *  - ignore_motion_model: optimimzation flag to discard motion model
    *      probabilities
    *  - enable_online_obs_pruning: optimization flag to enable

--- a/src/slam/belief_cube.hh
+++ b/src/slam/belief_cube.hh
@@ -5,8 +5,8 @@
 #include <unordered_map>
 #include <utility>
 #include "eigen3/Eigen/Dense"
+#include "models/sensor.hh"
 #include "raster_map.hh"
-#include "sensor_msgs/LaserScan.h"
 #include "util/matrix_hash.hh"
 
 namespace slam {
@@ -38,7 +38,7 @@ class BeliefCube {
    *      correlative scan matching.
    *  - odom_disp: The odometry displacement data for the motion model.
    *  - odom_angle_disp: The odometry rotation data for the motion model.
-   *  - new_obs: New sensor data for correlative scan matching.
+   *  - new_obs: New observations for correlative scan matching.
    *  - ignore_motion_model: optimimzation flag to discard motion model
    *      probabilities
    *  - enable_online_obs_pruning: optimization flag to enable
@@ -47,20 +47,20 @@ class BeliefCube {
   void eval(const RasterMap& ref_map,
             const Eigen::Vector2f& odom_disp,
             const double odom_angle_disp,
-            const sensor_msgs::LaserScan& new_obs,
+            const models::Observations& new_obs,
             const bool ignore_motion_model = false,
             const bool enable_obs_pruning = true);
 
   void eval_with_coarse(const RasterMap& ref_map,
                         const Eigen::Vector2f& odom_disp,
                         const double odom_angle_disp,
-                        const sensor_msgs::LaserScan& new_obs,
+                        const models::Observations& new_obs,
                         const BeliefCube& coarse_cube);
 
   double eval_range(const RasterMap& ref_map,
                     const Eigen::Vector2f& odom_disp,
                     const double odom_angle_disp,
-                    const sensor_msgs::LaserScan& new_obs,
+                    const models::Observations& new_obs,
                     const int dtheta_start,
                     const int dtheta_end,
                     const int dx_start,

--- a/src/slam/raster_map.hh
+++ b/src/slam/raster_map.hh
@@ -4,7 +4,7 @@
 #include <unordered_map>
 #include <vector>
 #include "eigen3/Eigen/Dense"
-#include "sensor_msgs/LaserScan.h"
+#include "models/sensor.hh"
 #include "util/matrix_hash.hh"
 
 namespace slam {
@@ -37,8 +37,8 @@ class RasterMap {
  public:
   RasterMap(const int resolution);
 
-  /// Generate the rasterized map given laser scan readings.
-  void eval(const sensor_msgs::LaserScan& obs);
+  /// Generate the rasterized map with the given observations.
+  void eval(const models::Observations& obs);
 
   /// Return the log probability value at the specified coordinate.
   double query(const double x, const double y) const;

--- a/src/slam/slam.cc
+++ b/src/slam/slam.cc
@@ -177,10 +177,11 @@ void SLAM::ObserveLaser(const sensor_msgs::LaserScan& scan_msg) {
   BeliefCube fine_cube(global_tx_windowsize, fine_tx_resolution, global_rot_windowsize,
                        global_rot_resolution);
 
-  coarse_cube.eval(prev_bel->coarse_ref_map.get(), bel->odom_disp, bel->odom_angle_disp, bel->obs,
-                   true, true);
+  const models::Observations sampled_obs = bel->obs.density_aware_sample(0.1);
+  coarse_cube.eval(prev_bel->coarse_ref_map.get(), bel->odom_disp, bel->odom_angle_disp,
+                   sampled_obs, true, true);
   fine_cube.eval_with_coarse(prev_bel->fine_ref_map.get(), bel->odom_disp, bel->odom_angle_disp,
-                             bel->obs, coarse_cube);
+                             sampled_obs, coarse_cube);
 
   const std::pair<Eigen::Vector2f, double> max_prob_belief = fine_cube.max_belief();
   bel->belief_disp = max_prob_belief.first;

--- a/src/slam/slam.cc
+++ b/src/slam/slam.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <memory>
 #include <utility>
 #include "common/common.hh"
 #include "eigen3/Eigen/Dense"
@@ -124,10 +125,10 @@ std::pair<Eigen::Vector2f, float> SLAM::GetPose() const {
     return std::make_pair(Eigen::Vector2f(0, 0), 0);
   }
 
-  return std::make_pair(belief_history.back().belief_loc, belief_history.back().belief_angle);
+  return std::make_pair(belief_history.back()->belief_loc, belief_history.back()->belief_angle);
 }
 
-void SLAM::ObserveLaser(const sensor_msgs::LaserScan& obs) {
+void SLAM::ObserveLaser(const sensor_msgs::LaserScan& scan_msg) {
   // A new laser scan has been observed. Decide whether to add it as a pose
   // for SLAM. If decided to add, align it to the scan from the last saved pose,
   // and save both the scan and the optimized pose.
@@ -142,12 +143,13 @@ void SLAM::ObserveLaser(const sensor_msgs::LaserScan& obs) {
   }
 
   if (belief_history.empty()) {
-    belief_history.emplace_back(last_obs_odom_loc, last_obs_odom_angle, prev_odom_loc_,
-                                prev_odom_angle_, obs);
-    belief_history.back().belief_disp = Eigen::Vector2f(0, 0);
-    belief_history.back().belief_angle_disp = 0;
-    belief_history.back().belief_loc = Eigen::Vector2f(0, 0);
-    belief_history.back().belief_angle = 0;
+    auto init_bel = std::make_shared<SLAMBelief>(last_obs_odom_loc, last_obs_odom_angle,
+                                                 prev_odom_loc_, prev_odom_angle_, scan_msg);
+    init_bel->belief_disp = Eigen::Vector2f(0, 0);
+    init_bel->belief_angle_disp = 0;
+    init_bel->belief_loc = Eigen::Vector2f(0, 0);
+    init_bel->belief_angle = 0;
+    belief_history.push_back(init_bel);
 
     last_obs_odom_loc = prev_odom_loc_;
     last_obs_odom_angle = prev_odom_angle_;
@@ -164,7 +166,9 @@ void SLAM::ObserveLaser(const sensor_msgs::LaserScan& obs) {
 
   auto __delayedfn = common::runtime_dist.auto_lap("SLAM::ObserveLaser");
 
-  SLAMBelief bel(last_obs_odom_loc, last_obs_odom_angle, prev_odom_loc_, prev_odom_angle_, obs);
+  auto bel = std::make_shared<SLAMBelief>(last_obs_odom_loc, last_obs_odom_angle, prev_odom_loc_,
+                                          prev_odom_angle_, scan_msg);
+  auto prev_bel = belief_history.back();
   last_obs_odom_loc = prev_odom_loc_;
   last_obs_odom_angle = prev_odom_angle_;
 
@@ -173,27 +177,27 @@ void SLAM::ObserveLaser(const sensor_msgs::LaserScan& obs) {
   BeliefCube fine_cube(global_tx_windowsize, fine_tx_resolution, global_rot_windowsize,
                        global_rot_resolution);
 
-  coarse_cube.eval(belief_history.back().coarse_ref_map.get(), bel.odom_disp, bel.odom_angle_disp,
-                   bel.obs, true, true);
-  fine_cube.eval_with_coarse(belief_history.back().fine_ref_map.get(), bel.odom_disp,
-                             bel.odom_angle_disp, bel.obs, coarse_cube);
+  coarse_cube.eval(prev_bel->coarse_ref_map.get(), bel->odom_disp, bel->odom_angle_disp, bel->obs,
+                   true, true);
+  fine_cube.eval_with_coarse(prev_bel->fine_ref_map.get(), bel->odom_disp, bel->odom_angle_disp,
+                             bel->obs, coarse_cube);
 
   const std::pair<Eigen::Vector2f, double> max_prob_belief = fine_cube.max_belief();
-  bel.belief_disp = max_prob_belief.first;
-  bel.belief_angle_disp = max_prob_belief.second;
+  bel->belief_disp = max_prob_belief.first;
+  bel->belief_angle_disp = max_prob_belief.second;
 
-  bel.belief_loc = belief_history.back().belief_loc +
-                   Eigen::Rotation2Df(belief_history.back().belief_angle) * bel.belief_disp;
-  bel.belief_angle =
-      math_util::ReflexToConvexAngle(belief_history.back().belief_angle + bel.belief_angle_disp);
+  bel->belief_loc =
+      prev_bel->belief_loc + Eigen::Rotation2Df(prev_bel->belief_angle) * bel->belief_disp;
+  bel->belief_angle =
+      math_util::ReflexToConvexAngle(prev_bel->belief_angle + bel->belief_angle_disp);
 
-  printf("Odometry reported disp: [%.4f, %.4f] %.2fº\n", bel.odom_disp.x(), bel.odom_disp.y(),
-         math_util::RadToDeg(bel.odom_angle_disp));
+  printf("Odometry reported disp: [%.4f, %.4f] %.2fº\n", bel->odom_disp.x(), bel->odom_disp.y(),
+         math_util::RadToDeg(bel->odom_angle_disp));
 
-  printf("Max likelihood disp: [%.4f, %.4f] %.2fº\n", bel.belief_disp.x(), bel.belief_disp.y(),
-         math_util::RadToDeg(bel.belief_angle_disp));
+  printf("Max likelihood disp: [%.4f, %.4f] %.2fº\n", bel->belief_disp.x(), bel->belief_disp.y(),
+         math_util::RadToDeg(bel->belief_angle_disp));
 
-  belief_history.push_back(std::move(bel));
+  belief_history.push_back(bel);
 }
 
 void SLAM::ObserveOdometry(const Vector2f& odom_loc, const float odom_angle) {
@@ -213,13 +217,13 @@ vector<Vector2f> SLAM::GetMap() {
 
   size_t i = last_update_idx + 1;
   for (; i < belief_history.size(); i++) {
-    const SLAMBelief& bel = belief_history[i];
+    std::shared_ptr<SLAMBelief> bel = belief_history[i];
 
     std::vector<Eigen::Vector2f> corrs =
-        bel.correlated_points(belief_history[i - 1].fine_ref_map.get());
-    const Eigen::Rotation2Df bel_rot(bel.belief_angle);
+        bel->correlated_points(belief_history[i - 1]->fine_ref_map.get());
+    const Eigen::Rotation2Df bel_rot(bel->belief_angle);
     for (const Eigen::Vector2f& point : corrs) {
-      map_.add_coord(bel_rot * point + bel.belief_loc);
+      map_.add_coord(bel_rot * point + bel->belief_loc);
     }
   }
   last_update_idx = i - 1;

--- a/src/slam/slam.h
+++ b/src/slam/slam.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <future>
+#include <memory>
 #include <vector>
 
 #include "belief_cube.hh"
@@ -85,7 +86,7 @@ class SLAM {
   float prev_odom_angle_;
   bool odom_initialized_;
 
-  std::vector<SLAMBelief> belief_history;
+  std::vector<std::shared_ptr<SLAMBelief>> belief_history;
 
   IdentityRasterMap map_;
 };

--- a/src/slam/slam.h
+++ b/src/slam/slam.h
@@ -26,6 +26,7 @@
 #include "belief_cube.hh"
 #include "eigen3/Eigen/Dense"
 #include "eigen3/Eigen/Geometry"
+#include "models/sensor.hh"
 #include "raster_map.hh"
 #include "sensor_msgs/LaserScan.h"
 
@@ -46,7 +47,7 @@ struct SLAMBelief {
   // evidence for this time step
   Eigen::Vector2f odom_disp;
   float odom_angle_disp;
-  sensor_msgs::LaserScan obs;
+  models::Observations obs;
 
   // posterior belief of this time step
   Eigen::Vector2f belief_disp;


### PR DESCRIPTION
## Additions

### `models::Observations` class

This class fuses and replaces `particle_filter::Observation`, `particle_filter::ParticleFilter::DensitySampledPointCloud`, and `models::PointsFromScan` to make point cloud generation and density-aware observation sampling more convenient across subsystem namespaces.

The particle filter and correlative scan matching-based SLAM have been reworked to use `models::Observations` instead of raw `sensor_msgs::LaserScan` messages. There did not seem to be a significant runtime difference for the particle filter nor CSM SLAM.

## `::models` API Changes

- `models::kLaserLoc` has been renamed to `models::kLaserOffset` to more accurately describe its purpose.
- `models::PointsFromScan()` has been replaced with `models::Observations::point_cloud()`
- `models::EvalLogSensorModel()` no longer performs a range validity check; this is now the responsibility of the caller. Callers were already performing this check, so we're removing unnecessary redundancy.

## Other CSM Changes

- Fixed segmentation fault in async tasks (395f9e3).
- Observations are now sampled prior to evaluating `BeliefCube`s. `BeliefCube::eval_range` now uses all observations provided to it.

## Results

Our CSM implementation is essentially only sensor model-based (in reality the motion model is used as a very small tiebreaker). Because of this, we get similar improvements as in the particle filter's sensor model with regard to increased correction for distant observations, particularly when the robot is moving backwards.

| Systematic Sampling | Density-Aware Sampling |
|-|-|
| ![systematic-gdc1] | ![density-gdc1] |
| ![systematic-gdc3] | ![density-gdc3] |

[systematic-gdc1]: https://user-images.githubusercontent.com/35668665/144320125-9b7287d6-fe88-44de-a7fa-a337426e93d6.jpg
[density-gdc1]: https://user-images.githubusercontent.com/35668665/144320082-347da99c-ded1-4b11-8433-e74a33e1d08d.jpg
[systematic-gdc3]: https://user-images.githubusercontent.com/35668665/144320205-df4d96f8-d321-43df-93f7-4ee4f588dc2f.jpg
[density-gdc3]: https://user-images.githubusercontent.com/35668665/144320179-90bd240b-3581-4e73-9769-80391625b206.jpg

Clearly there is still room for improvement, especially with angular drift, but the system is no longer catastrophically failing to localize with backwards movement.

Closes #83